### PR TITLE
#23 bucket should no longer use Random provider

### DIFF
--- a/journal/week1.md
+++ b/journal/week1.md
@@ -50,3 +50,22 @@ Instead of running the var flag, you can add variable to terraform.tfvars to mak
 
 TODO: document which terraform variables take precedence
 
+## Dealing with Configuration Drift
+
+## What happens if we lose our state file?
+
+If you lose your statefile, you most likely have to tear down all your cloud infrastructure manually. 
+
+You can use terraform import but it won't work for all cloud resources. You need to check the terraform providers documentation for which resources support import.
+
+### Fix Missing Resources with Terraform Import
+
+`terraform import aws_s3_bucket.website_bucket`
+
+[Terraform Import](https://developer.hashicorp.com/terraform/language/import)
+[AWS S3 Bucket Import](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#import)
+### Fix Manual Configuration
+
+If someone goes and deletes or modifies cloud resources manually through ClickOps.
+
+If we run Terraform plan with attempt to put our infrastructure back into the expected state fixing Configuration Drift

--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,8 @@
-# https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
-resource "random_string" "bucket_name" {
-  lower=true
-  upper=false
-  length = 32
-  special = false
-}
-
 # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
-resource "aws_s3_bucket" "example" {
+resource "aws_s3_bucket" "website_bucket" {
   # Bucket Naming Rules
   # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-  bucket = random_string.bucket_name.result
+  bucket = var.bucket_name
   tags = {
     UserUuid = var.user_uuid
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "random_bucket_name" {
-  value = random_string.bucket_name.result
+output "bucket_name" {
+  value = aws_s3_bucket.website_bucket
 }

--- a/providers.tf
+++ b/providers.tf
@@ -7,10 +7,7 @@ terraform {
 #     }
 #   }
   required_providers {
-    random = {
-      source = "hashicorp/random"
-      version = "3.5.1"
-    }
+
     aws = {
       source = "hashicorp/aws"
       version = "5.17.0"
@@ -19,9 +16,5 @@ terraform {
 }
 
 provider "aws" {
-  # Configuration options
-}
-
-provider "random" {
   # Configuration options
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,1 +1,2 @@
 user_uuid="d698d686-2c3c-4cd8-ab27-7ff00bc40152"
+bucket_name="1wakpj698imyssoncxa1hxx9bx74xknf"

--- a/variables.tf
+++ b/variables.tf
@@ -6,4 +6,15 @@ variable "user_uuid" {
     error_message    = "The user_uuid value is not a valid UUID."
   }
 }
+variable "bucket_name" {
+ description = "The name of the S3 bucket"
+ type        = string
 
+ validation {
+   condition     = (
+     length(var.bucket_name) >= 3 && length(var.bucket_name) <= 63 && 
+     can(regex("^[a-z0-9][a-z0-9-.]*[a-z0-9]$", var.bucket_name))
+   )
+   error_message = "The bucket name must be between 3 and 63 characters, start and end with a lowercase letter or number, and can contain only lowercase letters, numbers, hyphens, and dots."
+ }
+}


### PR DESCRIPTION
-  [x] use terraform import
- [x] purposely cause configuration drift via clickops, and correct state.